### PR TITLE
Update Sonar workflow branch triggers

### DIFF
--- a/.github/workflows/check-sonar.yml
+++ b/.github/workflows/check-sonar.yml
@@ -3,15 +3,7 @@ on:
   push:
     branches:
       - master
-      - main
-      - develop
       - 'release-v*'
-      - 'release/*'
-  pull_request:
-    branches:
-      - master
-      - main
-      - develop
       
 jobs:
   quality-check:


### PR DESCRIPTION
Removed 'main', 'develop', and pull_request triggers from the Sonar workflow. Now the workflow only runs on pushes to 'master' and 'release-v*' branches.

## Summary by Sourcery

CI:
- Restrict Sonar workflow to run only on pushes to master and release-v* branches by removing main, develop, release/*, and pull_request triggers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined continuous integration triggers to reduce unnecessary runs by limiting push events to stable and release branches and removing pull request-based triggers.
  * Retained existing pipeline steps (setup, install, test, validate, build, analysis) with no behavioral changes.
  * No user-facing impact; application functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->