### PR TITLE
Update schema type description and config versions

### DIFF
--- a/core/Schemas/schema.json
+++ b/core/Schemas/schema.json
@@ -42,17 +42,8 @@
           "description": "Schema description"
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "object",
-            "array",
-            "string",
-            "number",
-            "integer",
-            "boolean",
-            "null"
-          ],
-          "description": "JSON Schema type description"
+           "type": "string",
+           "description": "Schema type identifier"
         }
       },
       "required": [

--- a/vnext.config.json
+++ b/vnext.config.json
@@ -2,8 +2,8 @@
   "version": "1.0.0",
   "description": "vNext Core Domain Definition Configuration",
   "domain": "core",
-  "runtimeVersion": "0.0.17",
-  "schemaVersion": "0.0.16",
+  "runtimeVersion": "0.0.18",
+  "schemaVersion": "0.0.17",
   "paths": {
     "componentsRoot": "core",
     "tasks": "Tasks",


### PR DESCRIPTION
Refined the 'type' property description in schema.json for clarity and removed the enum restriction. Bumped runtimeVersion and schemaVersion in vnext.config.json to reflect latest changes.

## Summary by Sourcery

Refine the JSON schema’s 'type' property description and remove its enum restriction, and bump the runtime and schema versions in the vnext configuration to the latest values

Enhancements:
- Clarify the 'type' property description in schema.json and remove its enum restriction

Chores:
- Bump runtimeVersion and schemaVersion in vnext.config.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Relaxed validation for the schema “type” field by removing strict enumeration, allowing broader identifier values.
  * Updated the description of the “type” field to clarify it as a schema type identifier.

* **Chores**
  * Bumped runtime version to 0.0.18.
  * Updated schema version to 0.0.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->