### PR TITLE
Refactor HTTP schema fields for service calls

### DIFF
--- a/core/Schemas/task.json
+++ b/core/Schemas/task.json
@@ -86,9 +86,9 @@
                     ],
                     "default": "GET"
                   },
-                  "headers": {
+                  "body": {
                     "type": "object",
-                    "description": "HTTP header information"
+                    "description": "Service call body"
                   }
                 },
                 "required": [
@@ -196,9 +196,13 @@
                       "PATCH"
                     ]
                   },
-                  "data": {
+                  "body": {
                     "type": "object",
-                    "description": "Service call data"
+                    "description": "Service call body"
+                  },
+                  "headers": {
+                    "type": "object",
+                    "description": "Service call headers"
                   },
                   "queryString": {
                     "type": "string",

--- a/core/Workflows/sys-schemas.json
+++ b/core/Workflows/sys-schemas.json
@@ -430,9 +430,9 @@
                         ],
                         "default": "GET"
                       },
-                      "headers": {
+                      "body": {
                         "type": "object",
-                        "description": "HTTP header information"
+                        "description": "Service call body"
                       }
                     },
                     "required": [
@@ -540,9 +540,13 @@
                           "PATCH"
                         ]
                       },
-                      "data": {
+                      "body": {
                         "type": "object",
-                        "description": "Service call data"
+                        "description": "Service call body"
+                      },
+                      "headers": {
+                        "type": "object",
+                        "description": "Service call headers"
                       },
                       "queryString": {
                         "type": "string",


### PR DESCRIPTION
Renamed 'headers' to 'body' and updated descriptions for service call body fields in task and workflow schemas. Also clarified the distinction between 'body' and 'headers' in PATCH method definitions.

## Summary by Sourcery

Refactor HTTP schema definitions for service calls across task and workflow schemas by renaming the 'headers' field to 'body' and refining field descriptions to clarify request payload versus headers.

Enhancements:
- Rename 'headers' field to 'body' for service call parameters in task and workflow schemas
- Update descriptions for service call body fields to accurately reflect payload usage
- Clarify the distinction between request body and headers in PATCH method definitions