### PR TITLE
Update runtime and schema versions in config

### DIFF
--- a/vnext.config.json
+++ b/vnext.config.json
@@ -2,8 +2,8 @@
   "version": "1.0.0",
   "description": "vNext Core Domain Definition Configuration",
   "domain": "core",
-  "runtimeVersion": "0.0.18",
-  "schemaVersion": "0.0.17",
+  "runtimeVersion": "0.0.19",
+  "schemaVersion": "0.0.24",
   "paths": {
     "componentsRoot": "core",
     "tasks": "Tasks",


### PR DESCRIPTION
Bumped runtimeVersion to 0.0.19 and schemaVersion to 0.0.24 in vnext.config.json to use the latest versions.

## Summary by Sourcery

Chores:
- Bump runtimeVersion to 0.0.19 and schemaVersion to 0.0.24 in vnext.config.json