### PR TITLE
Update runtime and schema versions in config

### DIFF
--- a/vnext.config.json
+++ b/vnext.config.json
@@ -2,8 +2,8 @@
   "version": "1.0.0",
   "description": "vNext Core Domain Definition Configuration",
   "domain": "core",
-  "runtimeVersion": "0.0.20",
-  "schemaVersion": "0.0.25",
+  "runtimeVersion": "0.0.21",
+  "schemaVersion": "0.0.26",
   "paths": {
     "componentsRoot": "core",
     "tasks": "Tasks",


### PR DESCRIPTION
Bumped runtimeVersion to 0.0.21 and schemaVersion to 0.0.26 in vnext.config.json to reflect latest changes.

## Summary by Sourcery

Build:
- Bump runtimeVersion and schemaVersion in vnext.config.json to align with the latest released versions.