### PR TITLE
Add encoding option to mapping schema definitions

### DIFF
--- a/core/Schemas/workflow.json
+++ b/core/Schemas/workflow.json
@@ -630,7 +630,7 @@
                               "properties": {
                                 "type": {
                                   "const": "G",
-                                  "description": "Global mapping - code and location not reqired"
+                                  "description": "Global mapping - code and location not required"
                                 },
                                 "code": {
                                   "type": "string",
@@ -639,6 +639,15 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "additionalProperties": false
@@ -650,10 +659,10 @@
                                   "oneOf": [
                                     {
                                       "const": "L",
-                                      "description": "Local mapping - code and location is reqired"
+                                      "description": "Local mapping - code is required, location is optional"
                                     }
                                   ],
-                                  "description": "Task type"
+                                  "description": "Mapping type"
                                 },
                                 "code": {
                                   "type": "string",
@@ -662,11 +671,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             },
@@ -680,11 +697,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             }
@@ -712,6 +737,15 @@
                           "location": {
                             "type": "string",
                             "description": "Code file location"
+                          },
+                          "encoding": {
+                            "type": "string",
+                            "enum": [
+                              "B64",
+                              "NAT"
+                            ],
+                            "default": "B64",
+                            "description": "Encoding type. B64=Base64 (default), NAT=Native"
                           }
                         },
                         "additionalProperties": false
@@ -723,7 +757,7 @@
                             "oneOf": [
                               {
                                 "const": "L",
-                                "description": "Local mapping - code and location is required"
+                                "description": "Local mapping - code is required, location is optional"
                               }
                             ],
                             "description": "Mapping type"
@@ -735,11 +769,19 @@
                           "location": {
                             "type": "string",
                             "description": "Code file location"
+                          },
+                          "encoding": {
+                            "type": "string",
+                            "enum": [
+                              "B64",
+                              "NAT"
+                            ],
+                            "default": "B64",
+                            "description": "Encoding type. B64=Base64 (default), NAT=Native"
                           }
                         },
                         "required": [
-                          "code",
-                          "location"
+                          "code"
                         ],
                         "additionalProperties": false
                       },
@@ -753,11 +795,19 @@
                           "location": {
                             "type": "string",
                             "description": "Code file location"
+                          },
+                          "encoding": {
+                            "type": "string",
+                            "enum": [
+                              "B64",
+                              "NAT"
+                            ],
+                            "default": "B64",
+                            "description": "Encoding type. B64=Base64 (default), NAT=Native"
                           }
                         },
                         "required": [
-                          "code",
-                          "location"
+                          "code"
                         ],
                         "additionalProperties": false
                       },
@@ -1188,73 +1238,98 @@
                     "description": "Task reference to be run"
                   },
                   "mapping": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "const": "G",
-                                  "description": "Global mapping - code ve location not required"
-                                },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "oneOf": [
-                                    {
-                                      "const": "L",
-                                      "description": "Local mapping - code and location is reqired"
-                                    }
-                                  ],
-                                  "description": "Task type"
-                                },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "required": [
-                                "code",
-                                "location"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "required": [
-                                "code",
-                                "location"
-                              ],
-                              "additionalProperties": false
-                            }
-                          ],
-                          "description": "Mapping definition"
-                        }
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "const": "G",
+                            "description": "Global mapping - code and location not required"
+                          },
+                          "code": {
+                            "type": "string",
+                            "description": "Mapping code"
+                          },
+                          "location": {
+                            "type": "string",
+                            "description": "Code file location"
+                          },
+                          "encoding": {
+                            "type": "string",
+                            "enum": [
+                              "B64",
+                              "NAT"
+                            ],
+                            "default": "B64",
+                            "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "oneOf": [
+                              {
+                                "const": "L",
+                                "description": "Local mapping - code is required, location is optional"
+                              }
+                            ],
+                            "description": "Mapping type"
+                          },
+                          "code": {
+                            "type": "string",
+                            "description": "Mapping code"
+                          },
+                          "location": {
+                            "type": "string",
+                            "description": "Code file location"
+                          },
+                          "encoding": {
+                            "type": "string",
+                            "enum": [
+                              "B64",
+                              "NAT"
+                            ],
+                            "default": "B64",
+                            "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                          }
+                        },
+                        "required": [
+                          "code"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Mapping code"
+                          },
+                          "location": {
+                            "type": "string",
+                            "description": "Code file location"
+                          },
+                          "encoding": {
+                            "type": "string",
+                            "enum": [
+                              "B64",
+                              "NAT"
+                            ],
+                            "default": "B64",
+                            "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                          }
+                        },
+                        "required": [
+                          "code"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "Mapping definition"
+                  }
                 },
                 "additionalProperties": false
               },
@@ -1276,6 +1351,15 @@
                     "location": {
                       "type": "string",
                       "description": "Code file location"
+                    },
+                    "encoding": {
+                      "type": "string",
+                      "enum": [
+                        "B64",
+                        "NAT"
+                      ],
+                      "default": "B64",
+                      "description": "Encoding type. B64=Base64 (default), NAT=Native"
                     }
                   },
                   "additionalProperties": false
@@ -1287,7 +1371,7 @@
                       "oneOf": [
                         {
                           "const": "L",
-                          "description": "Local mapping - code and location is required"
+                          "description": "Local mapping - code is required, location is optional"
                         }
                       ],
                       "description": "Mapping type"
@@ -1299,11 +1383,19 @@
                     "location": {
                       "type": "string",
                       "description": "Code file location"
+                    },
+                    "encoding": {
+                      "type": "string",
+                      "enum": [
+                        "B64",
+                        "NAT"
+                      ],
+                      "default": "B64",
+                      "description": "Encoding type. B64=Base64 (default), NAT=Native"
                     }
                   },
                   "required": [
-                    "code",
-                    "location"
+                    "code"
                   ],
                   "additionalProperties": false
                 },
@@ -1317,11 +1409,19 @@
                     "location": {
                       "type": "string",
                       "description": "Code file location"
+                    },
+                    "encoding": {
+                      "type": "string",
+                      "enum": [
+                        "B64",
+                        "NAT"
+                      ],
+                      "default": "B64",
+                      "description": "Encoding type. B64=Base64 (default), NAT=Native"
                     }
                   },
                   "required": [
-                    "code",
-                    "location"
+                    "code"
                   ],
                   "additionalProperties": false
                 },
@@ -1706,6 +1806,15 @@
                               "location": {
                                 "type": "string",
                                 "description": "Code file location"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "additionalProperties": false
@@ -1717,10 +1826,10 @@
                                 "oneOf": [
                                   {
                                     "const": "L",
-                                    "description": "Local mapping - code and location is required"
+                                    "description": "Local mapping - code is required, location is optional"
                                   }
                                 ],
-                                "description": "Task type"
+                                "description": "Mapping type"
                               },
                               "code": {
                                 "type": "string",
@@ -1729,11 +1838,19 @@
                               "location": {
                                 "type": "string",
                                 "description": "Code file location"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "required": [
-                              "code",
-                              "location"
+                              "code"
                             ],
                             "additionalProperties": false
                           },
@@ -1747,11 +1864,19 @@
                               "location": {
                                 "type": "string",
                                 "description": "Code file location"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "required": [
-                              "code",
-                              "location"
+                              "code"
                             ],
                             "additionalProperties": false
                           }
@@ -1779,6 +1904,15 @@
                         "location": {
                           "type": "string",
                           "description": "Code file location"
+                        },
+                        "encoding": {
+                          "type": "string",
+                          "enum": [
+                            "B64",
+                            "NAT"
+                          ],
+                          "default": "B64",
+                          "description": "Encoding type. B64=Base64 (default), NAT=Native"
                         }
                       },
                       "additionalProperties": false
@@ -1790,7 +1924,7 @@
                           "oneOf": [
                             {
                               "const": "L",
-                              "description": "Local mapping - code and location is required"
+                              "description": "Local mapping - code is required, location is optional"
                             }
                           ],
                           "description": "Mapping type"
@@ -1802,11 +1936,19 @@
                         "location": {
                           "type": "string",
                           "description": "Code file location"
+                        },
+                        "encoding": {
+                          "type": "string",
+                          "enum": [
+                            "B64",
+                            "NAT"
+                          ],
+                          "default": "B64",
+                          "description": "Encoding type. B64=Base64 (default), NAT=Native"
                         }
                       },
                       "required": [
-                        "code",
-                        "location"
+                        "code"
                       ],
                       "additionalProperties": false
                     },
@@ -1820,11 +1962,19 @@
                         "location": {
                           "type": "string",
                           "description": "Code file location"
+                        },
+                        "encoding": {
+                          "type": "string",
+                          "enum": [
+                            "B64",
+                            "NAT"
+                          ],
+                          "default": "B64",
+                          "description": "Encoding type. B64=Base64 (default), NAT=Native"
                         }
                       },
                       "required": [
-                        "code",
-                        "location"
+                        "code"
                       ],
                       "additionalProperties": false
                     },
@@ -2128,8 +2278,7 @@
                           {
                             "type": "object",
                             "required": [
-                              "code",
-                              "location"
+                              "code"
                             ],
                             "properties": {
                               "code": {
@@ -2139,6 +2288,15 @@
                               "location": {
                                 "type": "string",
                                 "description": "Location of the mapping code file"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "additionalProperties": false
@@ -2627,73 +2785,98 @@
                             "description": "Task reference to be executed"
                           },
                           "mapping": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "const": "G",
-                                  "description": "Global mapping - code and location not reqired"
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "const": "G",
+                                    "description": "Global mapping - code and location not required"
+                                  },
+                                  "code": {
+                                    "type": "string",
+                                    "description": "Mapping code"
+                                  },
+                                  "location": {
+                                    "type": "string",
+                                    "description": "Code file location"
+                                  },
+                                  "encoding": {
+                                    "type": "string",
+                                    "enum": [
+                                      "B64",
+                                      "NAT"
+                                    ],
+                                    "default": "B64",
+                                    "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                                  }
                                 },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
+                                "additionalProperties": false
                               },
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "oneOf": [
-                                    {
-                                      "const": "L",
-                                      "description": "Local mapping - code and location is reqired"
-                                    }
-                                  ],
-                                  "description": "Task type"
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "oneOf": [
+                                      {
+                                        "const": "L",
+                                        "description": "Local mapping - code is required, location is optional"
+                                      }
+                                    ],
+                                    "description": "Mapping type"
+                                  },
+                                  "code": {
+                                    "type": "string",
+                                    "description": "Mapping code"
+                                  },
+                                  "location": {
+                                    "type": "string",
+                                    "description": "Code file location"
+                                  },
+                                  "encoding": {
+                                    "type": "string",
+                                    "enum": [
+                                      "B64",
+                                      "NAT"
+                                    ],
+                                    "default": "B64",
+                                    "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                                  }
                                 },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
+                                "required": [
+                                  "code"
+                                ],
+                                "additionalProperties": false
                               },
-                              "required": [
-                                "code",
-                                "location"
-                              ],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string",
+                                    "description": "Mapping code"
+                                  },
+                                  "location": {
+                                    "type": "string",
+                                    "description": "Code file location"
+                                  },
+                                  "encoding": {
+                                    "type": "string",
+                                    "enum": [
+                                      "B64",
+                                      "NAT"
+                                    ],
+                                    "default": "B64",
+                                    "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                                  }
                                 },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "required": [
-                                "code",
-                                "location"
-                              ],
-                              "additionalProperties": false
-                            }
-                          ],
-                          "description": "Mapping definition"
-                        }
+                                "required": [
+                                  "code"
+                                ],
+                                "additionalProperties": false
+                              }
+                            ],
+                            "description": "Mapping definition"
+                          }
                         },
                         "additionalProperties": false
                       },
@@ -2715,6 +2898,15 @@
                             "location": {
                               "type": "string",
                               "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
                           },
                           "additionalProperties": false
@@ -2726,7 +2918,7 @@
                               "oneOf": [
                                 {
                                   "const": "L",
-                                  "description": "Local mapping - code and location is required"
+                                  "description": "Local mapping - code is required, location is optional"
                                 }
                               ],
                               "description": "Mapping type"
@@ -2738,11 +2930,19 @@
                             "location": {
                               "type": "string",
                               "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
                           },
                           "required": [
-                            "code",
-                            "location"
+                            "code"
                           ],
                           "additionalProperties": false
                         },
@@ -2756,11 +2956,19 @@
                             "location": {
                               "type": "string",
                               "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
                           },
                           "required": [
-                            "code",
-                            "location"
+                            "code"
                           ],
                           "additionalProperties": false
                         },
@@ -2879,73 +3087,98 @@
                       "description": "Task reference to be run"
                     },
                     "mapping": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "const": "G",
-                                  "description": "Global mapping - code and location not reqired"
-                                },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "additionalProperties": false
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "const": "G",
+                              "description": "Global mapping - code and location not required"
                             },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "oneOf": [
-                                    {
-                                      "const": "L",
-                                      "description": "Local mapping - code and location is reqired"
-                                    }
-                                  ],
-                                  "description": "Task type"
-                                },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "required": [
-                                "code",
-                                "location"
-                              ],
-                              "additionalProperties": false
+                            "code": {
+                              "type": "string",
+                              "description": "Mapping code"
                             },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "required": [
-                                "code",
-                                "location"
+                            "location": {
+                              "type": "string",
+                              "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
                               ],
-                              "additionalProperties": false
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "oneOf": [
+                                {
+                                  "const": "L",
+                                  "description": "Local mapping - code is required, location is optional"
+                                }
+                              ],
+                              "description": "Mapping type"
+                            },
+                            "code": {
+                              "type": "string",
+                              "description": "Mapping code"
+                            },
+                            "location": {
+                              "type": "string",
+                              "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                            }
+                          },
+                          "required": [
+                            "code"
                           ],
-                          "description": "Mapping definition"
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "description": "Mapping code"
+                            },
+                            "location": {
+                              "type": "string",
+                              "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                            }
+                          },
+                          "required": [
+                            "code"
+                          ],
+                          "additionalProperties": false
                         }
+                      ],
+                      "description": "Mapping definition"
+                    }
                   },
                   "additionalProperties": false
                 },
@@ -3034,73 +3267,98 @@
                       "description": "Task reference to be run"
                     },
                     "mapping": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "const": "G",
-                                  "description": "Global mapping - code and location not reqired"
-                                },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "additionalProperties": false
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "const": "G",
+                              "description": "Global mapping - code and location not required"
                             },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "oneOf": [
-                                    {
-                                      "const": "L",
-                                      "description": "Local mapping - code and location is reqired"
-                                    }
-                                  ],
-                                  "description": "Task type"
-                                },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "required": [
-                                "code",
-                                "location"
-                              ],
-                              "additionalProperties": false
+                            "code": {
+                              "type": "string",
+                              "description": "Mapping code"
                             },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "required": [
-                                "code",
-                                "location"
+                            "location": {
+                              "type": "string",
+                              "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
                               ],
-                              "additionalProperties": false
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "oneOf": [
+                                {
+                                  "const": "L",
+                                  "description": "Local mapping - code is required, location is optional"
+                                }
+                              ],
+                              "description": "Mapping type"
+                            },
+                            "code": {
+                              "type": "string",
+                              "description": "Mapping code"
+                            },
+                            "location": {
+                              "type": "string",
+                              "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                            }
+                          },
+                          "required": [
+                            "code"
                           ],
-                          "description": "Mapping definition"
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "description": "Mapping code"
+                            },
+                            "location": {
+                              "type": "string",
+                              "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                            }
+                          },
+                          "required": [
+                            "code"
+                          ],
+                          "additionalProperties": false
                         }
+                      ],
+                      "description": "Mapping definition"
+                    }
                   },
                   "additionalProperties": false
                 },
@@ -3151,73 +3409,98 @@
                       }
                     },
                     "mapping": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "const": "G",
-                                  "description": "Global mapping - code and location not reqired"
-                                },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "additionalProperties": false
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "const": "G",
+                              "description": "Global mapping - code and location not required"
                             },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "oneOf": [
-                                    {
-                                      "const": "L",
-                                      "description": "Local mapping - code and location is reqired"
-                                    }
-                                  ],
-                                  "description": "Task type"
-                                },
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "required": [
-                                "code",
-                                "location"
-                              ],
-                              "additionalProperties": false
+                            "code": {
+                              "type": "string",
+                              "description": "Mapping code"
                             },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "code": {
-                                  "type": "string",
-                                  "description": "Mapping code"
-                                },
-                                "location": {
-                                  "type": "string",
-                                  "description": "Code file location"
-                                }
-                              },
-                              "required": [
-                                "code",
-                                "location"
+                            "location": {
+                              "type": "string",
+                              "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
                               ],
-                              "additionalProperties": false
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "oneOf": [
+                                {
+                                  "const": "L",
+                                  "description": "Local mapping - code is required, location is optional"
+                                }
+                              ],
+                              "description": "Mapping type"
+                            },
+                            "code": {
+                              "type": "string",
+                              "description": "Mapping code"
+                            },
+                            "location": {
+                              "type": "string",
+                              "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                            }
+                          },
+                          "required": [
+                            "code"
                           ],
-                          "description": "Mapping definition"
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "description": "Mapping code"
+                            },
+                            "location": {
+                              "type": "string",
+                              "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
+                            }
+                          },
+                          "required": [
+                            "code"
+                          ],
+                          "additionalProperties": false
                         }
+                      ],
+                      "description": "Mapping definition"
+                    }
                   },
                   "required": [
                     "order",

--- a/core/Schemas/workflow.json
+++ b/core/Schemas/workflow.json
@@ -350,8 +350,7 @@
                       {
                         "type": "object",
                         "required": [
-                          "code",
-                          "location"
+                          "code"
                         ],
                         "properties": {
                           "code": {
@@ -361,6 +360,15 @@
                           "location": {
                             "type": "string",
                             "description": "Location of the code file"
+                          },
+                          "encoding": {
+                            "type": "string",
+                            "enum": [
+                              "B64",
+                              "NAT"
+                            ],
+                            "default": "B64",
+                            "description": "Encoding type. B64=Base64 (default), NAT=Native"
                           }
                         },
                         "additionalProperties": false
@@ -376,17 +384,25 @@
                       {
                         "type": "object",
                         "required": [
-                          "code",
-                          "location"
+                          "code"
                         ],
                         "properties": {
                           "code": {
                             "type": "string",
-                            "description": "Rule code"
+                            "description": "Timer code"
                           },
                           "location": {
                             "type": "string",
                             "description": "Location of the code file"
+                          },
+                          "encoding": {
+                            "type": "string",
+                            "enum": [
+                              "B64",
+                              "NAT"
+                            ],
+                            "default": "B64",
+                            "description": "Encoding type. B64=Base64 (default), NAT=Native"
                           }
                         },
                         "additionalProperties": false
@@ -2511,8 +2527,7 @@
                         {
                           "type": "object",
                           "required": [
-                            "code",
-                            "location"
+                            "code"
                           ],
                           "properties": {
                             "code": {
@@ -2522,6 +2537,15 @@
                             "location": {
                               "type": "string",
                               "description": "Location of the code file"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
                           },
                           "additionalProperties": false
@@ -2537,17 +2561,25 @@
                         {
                           "type": "object",
                           "required": [
-                            "code",
-                            "location"
+                            "code"
                           ],
                           "properties": {
                             "code": {
                               "type": "string",
-                              "description": "Rule code"
+                              "description": "Timer code"
                             },
                             "location": {
                               "type": "string",
                               "description": "Location of the code file"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
                           },
                           "additionalProperties": false

--- a/core/Workflows/sys-schemas.json
+++ b/core/Workflows/sys-schemas.json
@@ -2060,7 +2060,7 @@
                                   "properties": {
                                     "type": {
                                       "const": "G",
-                                      "description": "Global mapping - code and location not reqired"
+                                      "description": "Global mapping - code and location not required"
                                     },
                                     "code": {
                                       "type": "string",
@@ -2069,6 +2069,15 @@
                                     "location": {
                                       "type": "string",
                                       "description": "Code file location"
+                                    },
+                                    "encoding": {
+                                      "type": "string",
+                                      "enum": [
+                                        "B64",
+                                        "NAT"
+                                      ],
+                                      "default": "B64",
+                                      "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                     }
                                   },
                                   "additionalProperties": false
@@ -2080,10 +2089,10 @@
                                       "oneOf": [
                                         {
                                           "const": "L",
-                                          "description": "Local mapping - code and location is reqired"
+                                          "description": "Local mapping - code is required, location is optional"
                                         }
                                       ],
-                                      "description": "Task type"
+                                      "description": "Mapping type"
                                     },
                                     "code": {
                                       "type": "string",
@@ -2092,11 +2101,19 @@
                                     "location": {
                                       "type": "string",
                                       "description": "Code file location"
+                                    },
+                                    "encoding": {
+                                      "type": "string",
+                                      "enum": [
+                                        "B64",
+                                        "NAT"
+                                      ],
+                                      "default": "B64",
+                                      "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                     }
                                   },
                                   "required": [
-                                    "code",
-                                    "location"
+                                    "code"
                                   ],
                                   "additionalProperties": false
                                 },
@@ -2110,11 +2127,19 @@
                                     "location": {
                                       "type": "string",
                                       "description": "Code file location"
+                                    },
+                                    "encoding": {
+                                      "type": "string",
+                                      "enum": [
+                                        "B64",
+                                        "NAT"
+                                      ],
+                                      "default": "B64",
+                                      "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                     }
                                   },
                                   "required": [
-                                    "code",
-                                    "location"
+                                    "code"
                                   ],
                                   "additionalProperties": false
                                 }
@@ -2142,6 +2167,15 @@
                               "location": {
                                 "type": "string",
                                 "description": "Code file location"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "additionalProperties": false
@@ -2153,7 +2187,7 @@
                                 "oneOf": [
                                   {
                                     "const": "L",
-                                    "description": "Local mapping - code and location is required"
+                                    "description": "Local mapping - code is required, location is optional"
                                   }
                                 ],
                                 "description": "Mapping type"
@@ -2165,11 +2199,19 @@
                               "location": {
                                 "type": "string",
                                 "description": "Code file location"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "required": [
-                              "code",
-                              "location"
+                              "code"
                             ],
                             "additionalProperties": false
                           },
@@ -2183,11 +2225,19 @@
                               "location": {
                                 "type": "string",
                                 "description": "Code file location"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "required": [
-                              "code",
-                              "location"
+                              "code"
                             ],
                             "additionalProperties": false
                           },
@@ -2624,7 +2674,7 @@
                             "properties": {
                               "type": {
                                 "const": "G",
-                                "description": "Global mapping - code ve location not required"
+                                "description": "Global mapping - code and location not required"
                               },
                               "code": {
                                 "type": "string",
@@ -2633,6 +2683,15 @@
                               "location": {
                                 "type": "string",
                                 "description": "Code file location"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "additionalProperties": false
@@ -2644,10 +2703,10 @@
                                 "oneOf": [
                                   {
                                     "const": "L",
-                                    "description": "Local mapping - code and location is reqired"
+                                    "description": "Local mapping - code is required, location is optional"
                                   }
                                 ],
-                                "description": "Task type"
+                                "description": "Mapping type"
                               },
                               "code": {
                                 "type": "string",
@@ -2656,11 +2715,19 @@
                               "location": {
                                 "type": "string",
                                 "description": "Code file location"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "required": [
-                              "code",
-                              "location"
+                              "code"
                             ],
                             "additionalProperties": false
                           },
@@ -2674,11 +2741,19 @@
                               "location": {
                                 "type": "string",
                                 "description": "Code file location"
+                              },
+                              "encoding": {
+                                "type": "string",
+                                "enum": [
+                                  "B64",
+                                  "NAT"
+                                ],
+                                "default": "B64",
+                                "description": "Encoding type. B64=Base64 (default), NAT=Native"
                               }
                             },
                             "required": [
-                              "code",
-                              "location"
+                              "code"
                             ],
                             "additionalProperties": false
                           }
@@ -2706,6 +2781,15 @@
                         "location": {
                           "type": "string",
                           "description": "Code file location"
+                        },
+                        "encoding": {
+                          "type": "string",
+                          "enum": [
+                            "B64",
+                            "NAT"
+                          ],
+                          "default": "B64",
+                          "description": "Encoding type. B64=Base64 (default), NAT=Native"
                         }
                       },
                       "additionalProperties": false
@@ -2717,7 +2801,7 @@
                           "oneOf": [
                             {
                               "const": "L",
-                              "description": "Local mapping - code and location is required"
+                              "description": "Local mapping - code is required, location is optional"
                             }
                           ],
                           "description": "Mapping type"
@@ -2729,11 +2813,19 @@
                         "location": {
                           "type": "string",
                           "description": "Code file location"
+                        },
+                        "encoding": {
+                          "type": "string",
+                          "enum": [
+                            "B64",
+                            "NAT"
+                          ],
+                          "default": "B64",
+                          "description": "Encoding type. B64=Base64 (default), NAT=Native"
                         }
                       },
                       "required": [
-                        "code",
-                        "location"
+                        "code"
                       ],
                       "additionalProperties": false
                     },
@@ -2747,11 +2839,19 @@
                         "location": {
                           "type": "string",
                           "description": "Code file location"
+                        },
+                        "encoding": {
+                          "type": "string",
+                          "enum": [
+                            "B64",
+                            "NAT"
+                          ],
+                          "default": "B64",
+                          "description": "Encoding type. B64=Base64 (default), NAT=Native"
                         }
                       },
                       "required": [
-                        "code",
-                        "location"
+                        "code"
                       ],
                       "additionalProperties": false
                     },
@@ -3136,6 +3236,15 @@
                                   "location": {
                                     "type": "string",
                                     "description": "Code file location"
+                                  },
+                                  "encoding": {
+                                    "type": "string",
+                                    "enum": [
+                                      "B64",
+                                      "NAT"
+                                    ],
+                                    "default": "B64",
+                                    "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                   }
                                 },
                                 "additionalProperties": false
@@ -3147,10 +3256,10 @@
                                     "oneOf": [
                                       {
                                         "const": "L",
-                                        "description": "Local mapping - code and location is required"
+                                        "description": "Local mapping - code is required, location is optional"
                                       }
                                     ],
-                                    "description": "Task type"
+                                    "description": "Mapping type"
                                   },
                                   "code": {
                                     "type": "string",
@@ -3159,11 +3268,19 @@
                                   "location": {
                                     "type": "string",
                                     "description": "Code file location"
+                                  },
+                                  "encoding": {
+                                    "type": "string",
+                                    "enum": [
+                                      "B64",
+                                      "NAT"
+                                    ],
+                                    "default": "B64",
+                                    "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                   }
                                 },
                                 "required": [
-                                  "code",
-                                  "location"
+                                  "code"
                                 ],
                                 "additionalProperties": false
                               },
@@ -3177,11 +3294,19 @@
                                   "location": {
                                     "type": "string",
                                     "description": "Code file location"
+                                  },
+                                  "encoding": {
+                                    "type": "string",
+                                    "enum": [
+                                      "B64",
+                                      "NAT"
+                                    ],
+                                    "default": "B64",
+                                    "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                   }
                                 },
                                 "required": [
-                                  "code",
-                                  "location"
+                                  "code"
                                 ],
                                 "additionalProperties": false
                               }
@@ -3209,6 +3334,15 @@
                             "location": {
                               "type": "string",
                               "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
                           },
                           "additionalProperties": false
@@ -3220,7 +3354,7 @@
                               "oneOf": [
                                 {
                                   "const": "L",
-                                  "description": "Local mapping - code and location is required"
+                                  "description": "Local mapping - code is required, location is optional"
                                 }
                               ],
                               "description": "Mapping type"
@@ -3232,11 +3366,19 @@
                             "location": {
                               "type": "string",
                               "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
                           },
                           "required": [
-                            "code",
-                            "location"
+                            "code"
                           ],
                           "additionalProperties": false
                         },
@@ -3250,11 +3392,19 @@
                             "location": {
                               "type": "string",
                               "description": "Code file location"
+                            },
+                            "encoding": {
+                              "type": "string",
+                              "enum": [
+                                "B64",
+                                "NAT"
+                              ],
+                              "default": "B64",
+                              "description": "Encoding type. B64=Base64 (default), NAT=Native"
                             }
                           },
                           "required": [
-                            "code",
-                            "location"
+                            "code"
                           ],
                           "additionalProperties": false
                         },
@@ -3558,8 +3708,7 @@
                               {
                                 "type": "object",
                                 "required": [
-                                  "code",
-                                  "location"
+                                  "code"
                                 ],
                                 "properties": {
                                   "code": {
@@ -3569,6 +3718,15 @@
                                   "location": {
                                     "type": "string",
                                     "description": "Location of the mapping code file"
+                                  },
+                                  "encoding": {
+                                    "type": "string",
+                                    "enum": [
+                                      "B64",
+                                      "NAT"
+                                    ],
+                                    "default": "B64",
+                                    "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                   }
                                 },
                                 "additionalProperties": false
@@ -4063,7 +4221,7 @@
                                     "properties": {
                                       "type": {
                                         "const": "G",
-                                        "description": "Global mapping - code and location not reqired"
+                                        "description": "Global mapping - code and location not required"
                                       },
                                       "code": {
                                         "type": "string",
@@ -4072,6 +4230,15 @@
                                       "location": {
                                         "type": "string",
                                         "description": "Code file location"
+                                      },
+                                      "encoding": {
+                                        "type": "string",
+                                        "enum": [
+                                          "B64",
+                                          "NAT"
+                                        ],
+                                        "default": "B64",
+                                        "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                       }
                                     },
                                     "additionalProperties": false
@@ -4083,10 +4250,10 @@
                                         "oneOf": [
                                           {
                                             "const": "L",
-                                            "description": "Local mapping - code and location is reqired"
+                                            "description": "Local mapping - code is required, location is optional"
                                           }
                                         ],
-                                        "description": "Task type"
+                                        "description": "Mapping type"
                                       },
                                       "code": {
                                         "type": "string",
@@ -4095,11 +4262,19 @@
                                       "location": {
                                         "type": "string",
                                         "description": "Code file location"
+                                      },
+                                      "encoding": {
+                                        "type": "string",
+                                        "enum": [
+                                          "B64",
+                                          "NAT"
+                                        ],
+                                        "default": "B64",
+                                        "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                       }
                                     },
                                     "required": [
-                                      "code",
-                                      "location"
+                                      "code"
                                     ],
                                     "additionalProperties": false
                                   },
@@ -4113,11 +4288,19 @@
                                       "location": {
                                         "type": "string",
                                         "description": "Code file location"
+                                      },
+                                      "encoding": {
+                                        "type": "string",
+                                        "enum": [
+                                          "B64",
+                                          "NAT"
+                                        ],
+                                        "default": "B64",
+                                        "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                       }
                                     },
                                     "required": [
-                                      "code",
-                                      "location"
+                                      "code"
                                     ],
                                     "additionalProperties": false
                                   }
@@ -4145,6 +4328,15 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "additionalProperties": false
@@ -4156,7 +4348,7 @@
                                   "oneOf": [
                                     {
                                       "const": "L",
-                                      "description": "Local mapping - code and location is required"
+                                      "description": "Local mapping - code is required, location is optional"
                                     }
                                   ],
                                   "description": "Mapping type"
@@ -4168,11 +4360,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             },
@@ -4186,11 +4386,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             },
@@ -4315,7 +4523,7 @@
                               "properties": {
                                 "type": {
                                   "const": "G",
-                                  "description": "Global mapping - code and location not reqired"
+                                  "description": "Global mapping - code and location not required"
                                 },
                                 "code": {
                                   "type": "string",
@@ -4324,6 +4532,15 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "additionalProperties": false
@@ -4335,10 +4552,10 @@
                                   "oneOf": [
                                     {
                                       "const": "L",
-                                      "description": "Local mapping - code and location is reqired"
+                                      "description": "Local mapping - code is required, location is optional"
                                     }
                                   ],
-                                  "description": "Task type"
+                                  "description": "Mapping type"
                                 },
                                 "code": {
                                   "type": "string",
@@ -4347,11 +4564,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             },
@@ -4365,11 +4590,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             }
@@ -4470,7 +4703,7 @@
                               "properties": {
                                 "type": {
                                   "const": "G",
-                                  "description": "Global mapping - code and location not reqired"
+                                  "description": "Global mapping - code and location not required"
                                 },
                                 "code": {
                                   "type": "string",
@@ -4479,6 +4712,15 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "additionalProperties": false
@@ -4490,10 +4732,10 @@
                                   "oneOf": [
                                     {
                                       "const": "L",
-                                      "description": "Local mapping - code and location is reqired"
+                                      "description": "Local mapping - code is required, location is optional"
                                     }
                                   ],
-                                  "description": "Task type"
+                                  "description": "Mapping type"
                                 },
                                 "code": {
                                   "type": "string",
@@ -4502,11 +4744,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             },
@@ -4520,11 +4770,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             }
@@ -4587,7 +4845,7 @@
                               "properties": {
                                 "type": {
                                   "const": "G",
-                                  "description": "Global mapping - code and location not reqired"
+                                  "description": "Global mapping - code and location not required"
                                 },
                                 "code": {
                                   "type": "string",
@@ -4596,6 +4854,15 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "additionalProperties": false
@@ -4607,10 +4874,10 @@
                                   "oneOf": [
                                     {
                                       "const": "L",
-                                      "description": "Local mapping - code and location is reqired"
+                                      "description": "Local mapping - code is required, location is optional"
                                     }
                                   ],
-                                  "description": "Task type"
+                                  "description": "Mapping type"
                                 },
                                 "code": {
                                   "type": "string",
@@ -4619,11 +4886,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             },
@@ -4637,11 +4912,19 @@
                                 "location": {
                                   "type": "string",
                                   "description": "Code file location"
+                                },
+                                "encoding": {
+                                  "type": "string",
+                                  "enum": [
+                                    "B64",
+                                    "NAT"
+                                  ],
+                                  "default": "B64",
+                                  "description": "Encoding type. B64=Base64 (default), NAT=Native"
                                 }
                               },
                               "required": [
-                                "code",
-                                "location"
+                                "code"
                               ],
                               "additionalProperties": false
                             }


### PR DESCRIPTION
Introduces an 'encoding' property to mapping objects in workflow and system schema JSON files, allowing selection between 'B64' (Base64, default) and 'NAT' (Native) encoding types. Also clarifies mapping type descriptions and updates required fields for local mappings to make 'location' optional.

## Summary by Sourcery

Add support for configurable encoding types in mapping schema definitions for workflows and system schemas.

New Features:
- Introduce an encoding property on mapping objects to select between Base64 and native encoding types in workflow and system schemas.

Enhancements:
- Clarify mapping type descriptions and relax local mapping requirements by making the location field optional in schema definitions.